### PR TITLE
Convert type to use controller name and action

### DIFF
--- a/lib/reduxable_plug.ex
+++ b/lib/reduxable_plug.ex
@@ -20,9 +20,16 @@ defmodule ReduxablePlug do
 
   defp extract_event_payload(conn) do
     %{
-      type: "#{conn.method} #{conn.request_path}",
+      type: controller_action(conn),
       params: conn.params
     }
+  end
+
+  defp controller_action(conn) do
+    controller = conn.private.phoenix_controller
+      |> to_string()
+      |> String.replace(~r/^Elixir\./, "")
+    "#{controller}##{conn.private.phoenix_action}"
   end
 
   defp endpoint do


### PR DESCRIPTION
Currently we send the method and path as the `type` parameter to
reducaltyics. This has the issue of parameters like `id` being included
as part of the action which makes it harder to make valuable charts.