### PR TITLE
Send action events in the background

### DIFF
--- a/lib/reduxable_plug.ex
+++ b/lib/reduxable_plug.ex
@@ -7,14 +7,16 @@ defmodule ReduxablePlug do
   end
 
   def call(conn, _opts) do
-    payload = conn |> extract_event_payload
-    HTTPoison.post endpoint() <> "pipeline/actions",
-      Poison.encode!(payload),
-      [
-        {"Content-Type", "application/json"},
-        {"reduxable-identifier", identifier()},
-        {"reduxable-client-identifier", get_client_identifier(conn)}
-      ]
+    ReduxablePlug.BackgroundJob.send fn() ->
+      payload = conn |> extract_event_payload
+      HTTPoison.post endpoint() <> "pipeline/actions",
+        Poison.encode!(payload),
+        [
+          {"Content-Type", "application/json"},
+          {"reduxable-identifier", identifier()},
+          {"reduxable-client-identifier", get_client_identifier(conn)}
+        ]
+      end
     conn
   end
 

--- a/lib/reduxable_plug/app.ex
+++ b/lib/reduxable_plug/app.ex
@@ -1,0 +1,14 @@
+defmodule ReduxablePlug.App do
+  use Application
+
+  def start(_type, _args) do
+    import Supervisor.Spec
+
+    children = [
+      supervisor(Task.Supervisor, [[name: ReduxablePlug.BackgroundJob.supervisor_name()]])
+    ]
+
+    opts = [strategy: :one_for_one, name: ReduxablePlug.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/reduxable_plug/background_job.ex
+++ b/lib/reduxable_plug/background_job.ex
@@ -1,0 +1,9 @@
+defmodule ReduxablePlug.BackgroundJob do
+  def send(fun) do
+    Task.Supervisor.start_child supervisor_name(), fun
+  end
+
+  def supervisor_name do
+    ReduxablePlug.TaskSupervisor
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,10 @@ defmodule ReduxablePlug.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     # Specify extra applications you'll use from Erlang/Elixir
-    [extra_applications: [:logger]]
+    [
+      extra_applications: [:logger],
+      mod: {ReduxablePlug.App, []}
+    ]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
So that there isn't as much of a performance hit. For high throughput
applications we'll probably want to queue and batch requests, but this
is fine for most every application we work on.

Tests were written in a way that they pass with this change. Woo hoo!